### PR TITLE
再生直後のエラー修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,12 @@ function updatePreview() {
     const html = marked.parse(line || ' ');
     const div = document.createElement('div');
     div.innerHTML = html;
-    const el = div.firstElementChild;
+    let el = div.firstElementChild;
+    if (!el) {
+      // パース結果が空の場合はプレーンテキストとして扱う
+      el = document.createElement('p');
+      el.textContent = line;
+    }
     el.dataset.index = idx;
     el.addEventListener('click', () => {
       current = idx;


### PR DESCRIPTION
## 概要
読み上げ終了直後に再生/一時停止ボタンを押すと `null` 参照が発生することがありました。`updatePreview` 内で `marked` の変換結果が空となった場合に備えてプレーンテキスト要素を生成するよう修正しました。

## 変更点
- `updatePreview` 内で `firstElementChild` が取得できなかった場合の処理を追加

## テスト
- `node` 上で `app.js` を読み込み、`updatePreview()` を呼び出してエラーが出ないことを確認しました（簡易テスト）。

------
https://chatgpt.com/codex/tasks/task_e_68874a4beaac8322a835030b3b370df7