### PR TITLE
読み上げ中の要素を自動スクロール

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,8 +70,13 @@ textarea.addEventListener('input', updatePreview);
 
 // 行ハイライト
 function highlight(idx) {
-  paragraphs.forEach(p => p.classList.remove('current'));
-  if (paragraphs[idx]) paragraphs[idx].classList.add('current');
+  paragraphs.forEach(p => p.classList.remove('current'))
+  const target = paragraphs[idx]
+  if (target) {
+    target.classList.add('current')
+    // 読み上げ中の要素が常に画面内に入るようスクロール
+    target.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  }
 }
 
 // 読み上げ実行


### PR DESCRIPTION
## Summary
- ハイライト処理で scrollIntoView を呼び出し、読み上げ対象を画面内に保持

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887b04b941483229c069219a3a32ff3