### PR TITLE
声質一覧のキーワード検索機能を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const volumeBar = document.getElementById('volume');
 const pitchBar = document.getElementById('pitch');
 const rateBox = document.getElementById('rate');
 const voiceBox = document.getElementById('voice');
+const voiceSearch = document.getElementById('voice-search');
 
 let paragraphs = [];
 let current = 0;
@@ -25,19 +26,33 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
+// 声質リストを描画
+function renderVoices(keyword = '') {
+  const selected = voiceBox.selectedOptions[0]?.textContent;
+  voiceBox.innerHTML = '';
+  voices
+    .filter(v => v.name.toLowerCase().includes(keyword.toLowerCase()))
+    .forEach(v => {
+      const opt = document.createElement('option');
+      opt.value = voices.indexOf(v);
+      opt.textContent = v.name;
+      if (v.name === selected) opt.selected = true;
+      voiceBox.appendChild(opt);
+    });
+}
+
 // 声質更新
 function updateVoices() {
   voices = speechSynthesis.getVoices();
-  voiceBox.innerHTML = '';
-  voices.forEach((v, i) => {
-    const opt = document.createElement('option');
-    opt.value = i;
-    opt.textContent = v.name;
-    voiceBox.appendChild(opt);
-  });
+  renderVoices(voiceSearch.value);
 }
 
 speechSynthesis.onvoiceschanged = updateVoices;
+
+// 声質検索
+voiceSearch.addEventListener('input', () => {
+  renderVoices(voiceSearch.value);
+});
 
 // プレビュー更新
 function updatePreview() {

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
     <label>ピッチ<input id="pitch" type="range" class="savecontrol" min="0" max="2" step="0.1"></label>
     <label>速度<select id="rate" class="savecontrol"></select></label>
     <label>声質<select id="voice" class="savecontrol" data-byname></select></label>
+    <label>声質検索<input id="voice-search" type="text" placeholder="キーワード"></label>
   </div>
   <div id="container">
     <textarea id="markdown" placeholder="Markdownテキストを入力"></textarea>


### PR DESCRIPTION
## 概要
- 声質検索用入力欄を追加
- 入力されたキーワードで声質リストを絞り込み表示

## テスト
- `npm test` (package.json がないため失敗)

------
https://chatgpt.com/codex/tasks/task_e_6896a53a42f4832294e95a4686d990fe