### PR TITLE
声質再読込時に選択を復元

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ const voiceBox = document.getElementById('voice');
 let paragraphs = [];
 let current = 0;
 let voices = [];
+let selectedVoiceName = '';
 
 document.addEventListener('DOMContentLoaded', () => {
   for (let i = 0.5; i <= 4; i += 0.5) {
@@ -27,6 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // 声質更新
 function updateVoices() {
+  const previousVoiceName = selectedVoiceName || voiceBox.selectedOptions[0]?.textContent || '';
   voices = speechSynthesis.getVoices();
   voiceBox.innerHTML = '';
   voices.forEach((v, i) => {
@@ -35,9 +37,21 @@ function updateVoices() {
     opt.textContent = v.name;
     voiceBox.appendChild(opt);
   });
+  const match = voices.findIndex(v => v.name === previousVoiceName);
+  if (match >= 0) {
+    voiceBox.selectedIndex = match;
+    selectedVoiceName = voices[match].name;
+  } else if (voices.length > 0) {
+    voiceBox.selectedIndex = 0;
+    selectedVoiceName = voices[0].name;
+  }
 }
 
 speechSynthesis.onvoiceschanged = updateVoices;
+
+voiceBox.addEventListener('change', () => {
+  selectedVoiceName = voiceBox.selectedOptions[0]?.textContent || '';
+});
 
 // プレビュー更新
 function updatePreview() {
@@ -121,8 +135,8 @@ function speakElement(el, callback) {
     u.volume = volume;
     u.pitch = pitch;
     u.rate = rate;
-    const selectedVoiceName = voiceBox.selectedOptions[0].textContent;
-    u.voice = voices.find(v => v.name === selectedVoiceName);
+    const currentVoiceName = voiceBox.selectedOptions[0]?.textContent || selectedVoiceName;
+    u.voice = voices.find(v => v.name === currentVoiceName);
     u.onend = () => speakNodes(idx + 1);
     speechSynthesis.speak(u);
   };

--- a/app.js
+++ b/app.js
@@ -28,7 +28,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // 声質更新
 function updateVoices() {
-  const previousVoiceName = selectedVoiceName || voiceBox.selectedOptions[0]?.textContent || '';
+  const storedVoiceName = localStorage.getItem('save_voice') ?? '';
+  const previousVoiceName = selectedVoiceName || voiceBox.selectedOptions[0]?.textContent || storedVoiceName;
   voices = speechSynthesis.getVoices();
   voiceBox.innerHTML = '';
   voices.forEach((v, i) => {


### PR DESCRIPTION
### Motivation
- `speechSynthesis` の声質リストが再読込されるタイミングで選択がリセットされる問題を解消するため、再構築後に直前の選択を復元するようにする。 

### Description
- `selectedVoiceName` 変数を追加して直前の声質名を保持するようにした。
- `updateVoices` 内で再構築前の選択名を参照して一致する声質があれば `voiceBox.selectedIndex` を復元する処理を追加した。
- `voiceBox` の `change` イベントで `selectedVoiceName` を更新するようにし、読み上げ時に `voiceBox` が未設定でも保持した名前を参照するように `SpeechSynthesisUtterance` の選択処理を修正した。 

### Testing
- 自動化テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e30fe9bfc83229129a97e3d342ffa)